### PR TITLE
OLMIS-6328: Revert changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-2.0.4 / WIP
-==================
-
-Improvements:
-* [OLMIS-6328](https://openlmis.atlassian.net/browse/OLMIS-6328): Remove call to /orderableFulfills on entering physical inventories
-
 2.0.3 / 2019-05-27
 ==================
 

--- a/src/stock-products/full-stock-card-summary-repository-impl.spec.js
+++ b/src/stock-products/full-stock-card-summary-repository-impl.spec.js
@@ -202,6 +202,21 @@ describe('FullStockCardSummaryRepositoryImpl', function() {
 
         });
 
+        it('should reject if orderable fulfills download fails', function() {
+            orderableFulfillsResourceMock.query.andReturn($q.reject());
+
+            var rejected;
+            fullStockCardSummaryRepositoryImpl.query()
+                .catch(function() {
+                    rejected = true;
+                });
+            $rootScope.$apply();
+
+            expect(rejected).toBe(true);
+            expect(stockCardSummaryResourceMock.query).toHaveBeenCalled();
+            expect(orderableFulfillsResourceMock.query).toHaveBeenCalled();
+        });
+
         it('should reject if orderable download fails', function() {
             orderableResourceMock.query.andReturn($q.reject());
 
@@ -214,6 +229,7 @@ describe('FullStockCardSummaryRepositoryImpl', function() {
 
             expect(rejected).toBe(true);
             expect(stockCardSummaryResourceMock.query).toHaveBeenCalled();
+            expect(orderableFulfillsResourceMock.query).toHaveBeenCalled();
             expect(orderableResourceMock.query).toHaveBeenCalled();
         });
 
@@ -229,6 +245,7 @@ describe('FullStockCardSummaryRepositoryImpl', function() {
 
             expect(rejected).toBe(true);
             expect(stockCardSummaryResourceMock.query).toHaveBeenCalled();
+            expect(orderableFulfillsResourceMock.query).toHaveBeenCalled();
             expect(orderableResourceMock.query).toHaveBeenCalled();
             expect(lotRepositoryImplMock.query).toHaveBeenCalled();
         });
@@ -242,6 +259,7 @@ describe('FullStockCardSummaryRepositoryImpl', function() {
             $rootScope.$apply();
 
             expect(stockCardSummaryResourceMock.query).toHaveBeenCalled();
+            expect(orderableFulfillsResourceMock.query).toHaveBeenCalled();
             expect(orderableResourceMock.query).toHaveBeenCalled();
             expect(lotRepositoryImplMock.query).toHaveBeenCalled();
             expect(result).not.toBeUndefined();


### PR DESCRIPTION
Despite it seems like the result of /orderableFulfills could be omitted (as later we're iterating over summaries anyway), it is in fact used to collect orderableIds that are not present in the summaries. I've missed this case previously, so those changes should be reverted.