### PR TITLE
OLMIS-7593: Fixed issue with saving the Unaccounted Quantity field in draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug fixes:
 * [OLMIS-7581](https://openlmis.atlassian.net/browse/OLMIS-7581): Fixed wrong order of displaying products after adding a new one in Physical Inventory - mobile app
 * [OLMIS-7582](https://openlmis.atlassian.net/browse/OLMIS-7582): fixed getStockAdjustment function when there is no draft in Physical Inventory - mobile app
 * [OLMIS-7599](https://openlmis.atlassian.net/browse/OLMIS-7599): fixed refreshing the app - mobile app
+* [OLMIS-7593](https://openlmis.atlassian.net/browse/OLMIS-7593): fixed issue with saving the Unaccounted Quantity field in draft
 
 Improvements:
 * [OLMIS-7588](https://openlmis.atlassian.net/browse/OLMIS-7588): Physical Inventory validation for unaccounted quantity - mobile app

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
@@ -628,6 +628,10 @@
                 return item.lot;
             });
 
+            draft.lineItems.forEach(function(item) {
+                checkUnaccountedStockAdjustments(item);
+            });
+
             vm.updateProgress();
             var orderableGroups = orderableGroupService.groupByOrderableId(draft.lineItems);
             vm.showVVMStatusColumn = orderableGroupService.areOrderablesUseVvm(orderableGroups);


### PR DESCRIPTION
Fixed the issue, error with unaccounted quantity does not occure anymore
![OLMIS-7593](https://user-images.githubusercontent.com/110475297/183023109-6235f2b5-ea85-4753-82c1-eda6cd6be9ed.gif)

