### PR TITLE
Remove post build cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,11 +88,6 @@ pipeline {
                         notifyAfterFailure()
                     }
                 }
-                cleanup {
-                    script {
-                        sh "sudo rm -rf ${WORKSPACE}/{*,.*} || true"
-                    }
-                }
             }
         }
         stage('Build reference-ui') {


### PR DESCRIPTION
Leave just the post-Sonar one. This is possible fix for "Can't find a suitable configuration file in this directory or any parent" build error.