### PR TITLE
CQI-10: use sonarcloud instead of sonarqube

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -1,0 +1,20 @@
+name: SonarCloud OpenLMIS-stockmanagement-ui Pipeline
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ bower_components
 .tmp
 /local-web-test/.local-web-test-env
 /local-web-test/.local-web-test-env-home
-.sonar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,64 +109,6 @@ pipeline {
                 }
             }
         }
-        stage('Sonar analysis') {
-            when {
-                expression {
-                    return VERSION.endsWith("SNAPSHOT")
-                }
-            }
-            steps {
-                withSonarQubeEnv('Sonar OpenLMIS') {
-                    withCredentials([string(credentialsId: 'SONAR_LOGIN', variable: 'SONAR_LOGIN'), string(credentialsId: 'SONAR_PASSWORD', variable: 'SONAR_PASSWORD')]) {
-                        script {
-                            sh '''
-                                set +x
-
-                                sudo rm -f .env
-                                touch .env
-
-                                SONAR_LOGIN_TEMP=$(echo $SONAR_LOGIN | cut -f2 -d=)
-                                SONAR_PASSWORD_TEMP=$(echo $SONAR_PASSWORD | cut -f2 -d=)
-                                echo "SONAR_LOGIN=$SONAR_LOGIN_TEMP" >> .env
-                                echo "SONAR_PASSWORD=$SONAR_PASSWORD_TEMP" >> .env
-                                echo "SONAR_BRANCH=$GIT_BRANCH" >> .env
-
-                                docker-compose run --entrypoint ./sonar.sh stockmanagement-ui
-                                docker-compose down --volumes
-                            '''
-                            // workaround because sonar plugin retrieve the path directly from the output
-                            sh 'echo "Working dir: ${WORKSPACE}/.sonar"'
-                        }
-                    }
-                }
-                timeout(time: 1, unit: 'HOURS') {
-                    script {
-                        def gate = waitForQualityGate()
-                        if (gate.status != 'OK') {
-                            echo 'Quality Gate FAILED'
-                            currentBuild.result = 'UNSTABLE'
-                        }
-                    }
-                }
-            }
-            post {
-                unstable {
-                    script {
-                        notifyAfterFailure()
-                    }
-                }
-                failure {
-                    script {
-                        notifyAfterFailure()
-                    }
-                }
-                cleanup {
-                    script {
-                        sh "sudo rm -rf ${WORKSPACE}/{*,.*} || true"
-                    }
-                }
-            }
-        }
         stage('Push image') {
             when {
                 expression {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=OpenLMIS_openlmis-stockmanagement-ui
+sonar.organization=openlmis
+sonar.projectName=openlmis-stockmanagement-ui
+sonar.sources=src
+sonar.sourceEncoding=UTF-8

--- a/sonar.sh
+++ b/sonar.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Update everything (just in case)
-npm rebuild
-npm install --no-optional
-
-# Built and test
-grunt
-grunt sonar --sonarLogin=$SONAR_LOGIN --sonarPassword=$SONAR_PASSWORD --sonarBranch=$SONAR_BRANCH


### PR DESCRIPTION
[CQI-10](https://openlmis.atlassian.net/browse/CQI-10)

Within the context of this PR, I've implemented a GitHub workflow for static code analysis using SonarCloud. Additionally, I removed the SonarQube stage from the Jenkins pipeline as well as the redundant SonarQube script.

[CQI-10]: https://openlmis.atlassian.net/browse/CQI-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ