### PR TITLE
OLMIS-7748: Fix filtering 'includeInactive' on the Physical Inventory page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Improvements:
 * [OLMIS-7954](https://openlmis.atlassian.net/browse/OLMIS-7954): Added fixes to improve performance on login page
 * [OLMIS-7991](https://openlmis.atlassian.net/browse/OLMIS-7991): Filtered out lots that not expired on Issue screeen
 
+Bug fixes:
+* [OLMIS-7748](https://openlmis.atlassian.net/browse/OLMIS-7748): Fix filtering 'includeInactive' on the Physical Inventory page
+
 2.1.5 / 2023-06-26
 ==================
 Bug fixes:

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
@@ -652,7 +652,7 @@
 
             _.chain(displayLineItemsGroup).flatten()
                 .each(function(item) {
-                    if (!item.active) {
+                    if (!item.active && item.stockOnHand === 0) {
                         activeError = 'stockPhysicalInventoryDraft.submitInvalidActive';
                     } else if (vm.validateQuantity(item) || vm.validateUnaccountedQuantity(item)) {
                         qtyError = 'stockPhysicalInventoryDraft.submitInvalid';

--- a/src/stock-physical-inventory/physical-inventory.service.js
+++ b/src/stock-physical-inventory/physical-inventory.service.js
@@ -171,7 +171,7 @@
 
             if (!includeInactive) {
                 result = _.filter(result, function(item) {
-                    return item.active;
+                    return item.active || item.stockOnHand !== 0;
                 });
             }
 

--- a/src/stock-physical-inventory/physical-inventory.service.spec.js
+++ b/src/stock-physical-inventory/physical-inventory.service.spec.js
@@ -40,6 +40,7 @@ describe('physicalInventoryService', function() {
         var orderable1 = new this.OrderableDataBuilder().withFullProductName('Streptococcus Pneumoniae Vaccine II')
                 .build(),
             orderable2 = new this.OrderableDataBuilder().build(),
+            orderable3 = new this.OrderableDataBuilder().build(),
             lot = new this.LotDataBuilder().build(),
             stockAdjustments = [new this.PhysicalInventoryLineItemAdjustmentDataBuilder().build()];
 
@@ -48,13 +49,17 @@ describe('physicalInventoryService', function() {
                 .withStockAdjustments(stockAdjustments)
                 .buildAsAdded(),
             new this.PhysicalInventoryLineItemDataBuilder().withOrderable(orderable2)
-                .withStockOnHand(null)
+                .withStockOnHand(0)
                 .withQuantity(4)
                 .buildAsAdded(),
             new this.PhysicalInventoryLineItemDataBuilder().withOrderable(orderable2)
                 .withLot(lot)
-                .withStockOnHand(null)
+                .withStockOnHand(0)
                 .withQuantity(null)
+                .buildAsAdded(),
+            new this.PhysicalInventoryLineItemDataBuilder().withOrderable(orderable3)
+                .withStockOnHand(null)
+                .withQuantity(40)
                 .buildAsAdded()
         ];
 
@@ -206,7 +211,7 @@ describe('physicalInventoryService', function() {
 
         it('should search by quantity', function() {
             expect(this.physicalInventoryService.search('4', this.physicalInventoryLineItems, null))
-                .toEqual([this.physicalInventoryLineItems[1]]);
+                .toEqual([this.physicalInventoryLineItems[1], this.physicalInventoryLineItems[3]]);
         });
 
         it('should search by lotCode', function() {
@@ -219,7 +224,8 @@ describe('physicalInventoryService', function() {
             this.messageService.get.andReturn('No lot defined');
 
             expect(this.physicalInventoryService.search('No lot defined', this.physicalInventoryLineItems, null))
-                .toEqual([this.physicalInventoryLineItems[0], this.physicalInventoryLineItems[1]]);
+                .toEqual([this.physicalInventoryLineItems[0], this.physicalInventoryLineItems[1],
+                    this.physicalInventoryLineItems[3]]);
         });
 
         it('should search by expirationDate', function() {
@@ -230,15 +236,21 @@ describe('physicalInventoryService', function() {
         it('should search by only active', function() {
             var lineItems = [
                 {
-                    active: true
+                    active: true,
+                    stockOnHand: 20
                 },
                 {
-                    active: false
+                    active: false,
+                    stockOnHand: 0
+                },
+                {
+                    active: false,
+                    stockOnHand: null
                 }
             ];
 
             expect(this.physicalInventoryService.search('', lineItems, false))
-                .toEqual([lineItems[0]]);
+                .toEqual([lineItems[0], lineItems[2]]);
         });
 
         it('should find include inactive', function() {
@@ -272,10 +284,11 @@ describe('physicalInventoryService', function() {
         this.$httpBackend.flush();
         this.$rootScope.$apply();
 
-        expect(result.lineItems.length).toBe(3);
+        expect(result.lineItems.length).toBe(4);
         expect(result.lineItems[0].quantity).toBe(3);
         expect(result.lineItems[1].quantity).toBe(4);
         expect(result.lineItems[2].quantity).toBe(null);
+        expect(result.lineItems[3].quantity).toBe(40);
     });
 
     //eslint-disable-next-line jasmine/missing-expect


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/OLMIS-7748

Changes:
Fix filtering 'includeInactive' on the Physical Inventory page