### PR TITLE
OLMIS-8177: Unify Physical Inventory and Adjustment validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 2.2.0-SNAPSHOT (WIP)
 ==================
 
+Bug fixes:
+* [OLMIS-8177](https://openlmis.atlassian.net/browse/OLMIS-8177): Unify packs/doses validation indicators in Physical Inventory and Stock Adjustment - removed the tooltip-less exclamation mark on the Add Reasons button, the unaccounted quantity indicator now revalidates when the quantity changes, and the adjustment occurred date shows a consistent required validation instead of the HTML5 required attribute.
+
 2.1.11 / 2026-06-09
 ==================
 * [ODRC-24](https://openlmis.atlassian.net/browse/ODRC-24) Global header and translations implemented for native reports

--- a/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
@@ -327,6 +327,43 @@ describe('StockAdjustmentCreationController', function() {
         expect(vm.addedLineItems).toEqual([lineItem2]);
     });
 
+    describe('validateDate', function() {
+
+        it('should set occurredDateInvalid when occurred date is undefined', function() {
+            var lineItem = {
+                occurredDate: undefined,
+                $errors: {}
+            };
+
+            vm.validateDate(lineItem);
+
+            expect(lineItem.$errors.occurredDateInvalid).toBe(true);
+        });
+
+        it('should set occurredDateInvalid when occurred date is null', function() {
+            var lineItem = {
+                occurredDate: null,
+                $errors: {}
+            };
+
+            vm.validateDate(lineItem);
+
+            expect(lineItem.$errors.occurredDateInvalid).toBe(true);
+        });
+
+        it('should not set occurredDateInvalid when occurred date is present', function() {
+            var lineItem = {
+                occurredDate: '2017-01-01',
+                $errors: {}
+            };
+
+            vm.validateDate(lineItem);
+
+            expect(lineItem.$errors.occurredDateInvalid).toBe(false);
+        });
+
+    });
+
     describe('addProduct', function() {
 
         beforeEach(function() {

--- a/src/stock-adjustment-creation/adjustment-creation.html
+++ b/src/stock-adjustment-creation/adjustment-creation.html
@@ -97,7 +97,7 @@
                     <td ng-if="vm.showReasonDropdown">
                         <input type="text" ng-show="lineItem.reason.isFreeTextAllowed" ng-model="lineItem.reasonFreeText" rows="1" cols="15"></input>
                     </td>
-                    <td class="digit-cell" openlmis-invalid="{{lineItem.$errors.quantityInvalid ? lineItem.$errors.quantityInvalid : '' | message}}">
+                    <td class="digit-cell" openlmis-invalid="{{lineItem.$errors.quantityInvalid ? lineItem.$errors.quantityInvalid : ''}}">
                         <openlmis-quantity-unit-input
                                 show-in-doses="vm.showInDoses()"
                                 item="lineItem"
@@ -113,9 +113,9 @@
                             placeholder="{{'stockAdjustmentCreation.selectStatus' | message}}">
                         </select>
                     </td>
-                    <td class="date-cell">
+                    <td class="date-cell" openlmis-invalid="{{lineItem.$errors.occurredDateInvalid ? 'openlmisForm.required' : '' | message}}">
                         <input id="lineItem.occurredDate" type="date" ng-model="lineItem.occurredDate"
-                            ng-change="vm.validateDate(lineItem)" max-date="vm.maxDate" required inputmode="none"/>
+                            ng-change="vm.validateDate(lineItem)" max-date="vm.maxDate" inputmode="none"/>
                     </td>
                     <td>
                         <button type="button" class="danger" ng-click="vm.remove(lineItem)">{{vm.key('remove') | message}}</button>

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.controller.js
@@ -793,6 +793,7 @@
             vm.updateProgress();
             vm.validateQuantity(lineItem);
             vm.checkUnaccountedStockAdjustments(lineItem);
+            vm.validateUnaccountedQuantity(lineItem);
             vm.dataChanged = !vm.dataChanged;
         }
 

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.controller.spec.js
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.controller.spec.js
@@ -588,6 +588,14 @@ describe('PhysicalInventoryDraftController', function() {
             expect(this.vm.checkUnaccountedStockAdjustments).toHaveBeenCalledWith(this.lineItem);
         });
 
+        it('should validate unaccounted quantity', function() {
+            spyOn(this.vm, 'validateUnaccountedQuantity');
+
+            this.vm.quantityChanged(this.lineItem);
+
+            expect(this.vm.validateUnaccountedQuantity).toHaveBeenCalledWith(this.lineItem);
+        });
+
     });
 
     describe('addProduct', function() {

--- a/src/stock-physical-inventory-draft/physical-inventory-draft.html
+++ b/src/stock-physical-inventory-draft/physical-inventory-draft.html
@@ -85,8 +85,7 @@
                         show-in-doses="vm.showInDoses()" 
                         item="lineItem"
                         net-content="lineItem.orderable.netContent"
-                        on-change-quantity="vm.quantityChanged(lineItem)"
-                        input-class="{'has-popover is-invalid': vm.validateOnPageChange()}"/>
+                        on-change-quantity="vm.quantityChanged(lineItem)"/>
                 </td>
                 <td ng-if="vm.showVVMStatusColumn" class="digit-cell">
                     <select ng-if="lineItem.orderable.extraData.useVVM == 'true'"
@@ -101,12 +100,10 @@
                         ng-model="lineItem.stockAdjustments"
                         line-item="lineItem"
                         reasons="vm.reasons"
-                        ng-class="{'has-popover is-invalid': vm.validateOnPageChange()}"
                         ng-change="vm.checkUnaccountedStockAdjustments(lineItem); vm.validateUnaccountedQuantity(lineItem)"
                         />
                 <td align="right"
-                    ng-class="{'has-popover is-invalid': vm.validateOnPageChange()}"
-                    openlmis-invalid="{{lineItem.unaccountedQuantityInvalid | message}}">
+                    openlmis-invalid="{{lineItem.unaccountedQuantityInvalid ? lineItem.unaccountedQuantityInvalid : ''}}">
                     {{vm.recalculateQuantity(lineItem.unaccountedQuantity, lineItem.orderable.netContent)}}
                 </td>
                 </td>

--- a/src/stock-reasons-modal/_stock-reasons.scss
+++ b/src/stock-reasons-modal/_stock-reasons.scss
@@ -31,8 +31,4 @@ td stock-reasons > button {
     }
 }
 
-// OLMIS-8177: removed `.is-invalid stock-reasons button::after` deaf exclamation mark.
-// The Add Reasons button is not a required field; the red ❗ was driven purely by the
-// row-level `.is-invalid` (tr-is-invalid cascade) without any tooltip/message. The
-// meaningful indicator + tooltip stays on the actually-invalid cell (Current Stock /
-// Unaccounted Quantity) via the openlmis-invalid directive.
+// OLMIS-8177: removed deaf `.is-invalid stock-reasons button::after` mark (no tooltip).

--- a/src/stock-reasons-modal/_stock-reasons.scss
+++ b/src/stock-reasons-modal/_stock-reasons.scss
@@ -31,15 +31,8 @@ td stock-reasons > button {
     }
 }
 
-.is-invalid stock-reasons button {
-    font-family: $font-family;
-    &::after {
-        color: $brand-danger;
-        content: "\f06a";
-        font-family: FontAwesome;
-        display: inline-block;
-        @include margin-left(0.5em);
-        flex-grow: 1;
-        @include text-align(right);
-    }
-}
+// OLMIS-8177: removed `.is-invalid stock-reasons button::after` deaf exclamation mark.
+// The Add Reasons button is not a required field; the red ❗ was driven purely by the
+// row-level `.is-invalid` (tr-is-invalid cascade) without any tooltip/message. The
+// meaningful indicator + tooltip stays on the actually-invalid cell (Current Stock /
+// Unaccounted Quantity) via the openlmis-invalid directive.


### PR DESCRIPTION
Removes the tooltip-less Add Reasons mark, revalidates unaccounted quantity on change, and validates the adjustment occurred date in the controller instead of the HTML5 required attribute.