### PR TITLE
OLMIS-8191: Wrap and cap stock adjustment free-text; wrap Stock Card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842): Added Transaction History header, packs/doses support, reorder stockmanagement menu entries
 * [SELV3-841](https://openlmis.atlassian.net/browse/SELV3-841): Added prompt to print the stock event report after submitting a stock issue or receive
 * [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842): Added Transaction History view with filtering and a clickable document number link on the stock card
+* [OLMIS-8191](https://openlmis.atlassian.net/browse/OLMIS-8191): Wrap long source/destination and reason free-text in stock adjustment cells (editing) and on the Stock Card (read-only); the reason comment is now a textarea, and both free-text fields are capped to 255 characters with a live character counter.
 
 2.1.11 / 2026-06-09
 ==================

--- a/src/stock-adjustment-creation/adjustment-creation.controller.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.js
@@ -36,7 +36,7 @@
         'dateUtils', 'displayItems', 'ADJUSTMENT_TYPE', 'UNPACK_REASONS', 'REASON_TYPES', 'STOCKCARD_STATUS',
         'hasPermissionToAddNewLot', 'LotResource', '$q', 'editLotModalService', 'moment', 'QUANTITY_UNIT',
         'quantityUnitCalculateService', 'signatureModalService', '$window', 'stockmanagementUrlFactory',
-        'accessTokenFactory', 'localStorageService'
+        'accessTokenFactory', 'localStorageService', 'STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH'
     ];
 
     function controller($scope, $state, $stateParams, $filter, confirmDiscardService, program,
@@ -46,9 +46,12 @@
                         alertService, dateUtils, displayItems, ADJUSTMENT_TYPE, UNPACK_REASONS, REASON_TYPES,
                         STOCKCARD_STATUS, hasPermissionToAddNewLot, LotResource, $q, editLotModalService, moment,
                         QUANTITY_UNIT, quantityUnitCalculateService, signatureModalService, $window,
-                        stockmanagementUrlFactory, accessTokenFactory, localStorageService) {
+                        stockmanagementUrlFactory, accessTokenFactory, localStorageService,
+                        STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH) {
         var vm = this,
             previousAdded = {};
+
+        vm.freeTextMaxLength = STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH;
 
         vm.expirationDateChanged = expirationDateChanged;
         vm.newLotCodeChanged = newLotCodeChanged;

--- a/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
@@ -113,6 +113,10 @@ describe('StockAdjustmentCreationController', function() {
             expect(stateParams.page).toEqual(0);
         });
 
+        it('should expose the free-text max length', function() {
+            expect(vm.freeTextMaxLength).toBe(255);
+        });
+
         it('should set showVVMStatusColumn to true if any orderable use vvm', function() {
 
             vm = initController([this.orderableGroup]);

--- a/src/stock-adjustment-creation/adjustment-creation.html
+++ b/src/stock-adjustment-creation/adjustment-creation.html
@@ -86,7 +86,9 @@
                         </select>
                     </td>
                     <td ng-show="vm.srcDstAssignments">
-                        <textarea class="openlmis-long-text" characters-left maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}" ng-show="lineItem.assignment.isFreeTextAllowed" ng-model="lineItem.srcDstFreeText" rows="1"></textarea>
+                        <textarea class="openlmis-long-text" characters-left
+                            ng-attr-maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}"
+                            ng-show="lineItem.assignment.isFreeTextAllowed" ng-model="lineItem.srcDstFreeText" rows="1"></textarea>
                     </td>
                     <td ng-if="vm.showReasonDropdown" openlmis-invalid="{{lineItem.$errors.reasonInvalid ? 'openlmisForm.required' : '' | message}}" class="digit-cell">
                         <select ng-model="lineItem.reason"
@@ -95,7 +97,9 @@
                         </select>
                     </td>
                     <td ng-if="vm.showReasonDropdown">
-                        <textarea class="openlmis-long-text" characters-left maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}" ng-show="lineItem.reason.isFreeTextAllowed" ng-model="lineItem.reasonFreeText" rows="1"></textarea>
+                        <textarea class="openlmis-long-text" characters-left
+                            ng-attr-maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}"
+                            ng-show="lineItem.reason.isFreeTextAllowed" ng-model="lineItem.reasonFreeText" rows="1"></textarea>
                     </td>
                     <td class="digit-cell" openlmis-invalid="{{lineItem.$errors.quantityInvalid ? lineItem.$errors.quantityInvalid : '' | message}}">
                         <openlmis-quantity-unit-input

--- a/src/stock-adjustment-creation/adjustment-creation.html
+++ b/src/stock-adjustment-creation/adjustment-creation.html
@@ -86,7 +86,7 @@
                         </select>
                     </td>
                     <td ng-show="vm.srcDstAssignments">
-                        <textarea ng-show="lineItem.assignment.isFreeTextAllowed" ng-model="lineItem.srcDstFreeText" rows="1" cols="15"></textarea>
+                        <textarea class="openlmis-long-text" characters-left maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}" ng-show="lineItem.assignment.isFreeTextAllowed" ng-model="lineItem.srcDstFreeText" rows="1"></textarea>
                     </td>
                     <td ng-if="vm.showReasonDropdown" openlmis-invalid="{{lineItem.$errors.reasonInvalid ? 'openlmisForm.required' : '' | message}}" class="digit-cell">
                         <select ng-model="lineItem.reason"
@@ -95,7 +95,7 @@
                         </select>
                     </td>
                     <td ng-if="vm.showReasonDropdown">
-                        <input type="text" ng-show="lineItem.reason.isFreeTextAllowed" ng-model="lineItem.reasonFreeText" rows="1" cols="15"></input>
+                        <textarea class="openlmis-long-text" characters-left maxlength="{{vm.freeTextMaxLength}}" ng-maxlength="{{vm.freeTextMaxLength}}" ng-show="lineItem.reason.isFreeTextAllowed" ng-model="lineItem.reasonFreeText" rows="1"></textarea>
                     </td>
                     <td class="digit-cell" openlmis-invalid="{{lineItem.$errors.quantityInvalid ? lineItem.$errors.quantityInvalid : '' | message}}">
                         <openlmis-quantity-unit-input

--- a/src/stock-adjustment-creation/stock-adjustment-free-text-max-length.constant.js
+++ b/src/stock-adjustment-creation/stock-adjustment-free-text-max-length.constant.js
@@ -1,0 +1,30 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+    * @ngdoc object
+    * @name stock-adjustment-creation.STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH
+    *
+    * @description
+    * Max length for the source/destination and reason free-text fields (backend varchar limit).
+    */
+    angular
+        .module('stock-adjustment-creation')
+        .constant('STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH', 255);
+})();

--- a/src/stock-card/stock-card.html
+++ b/src/stock-card/stock-card.html
@@ -59,15 +59,15 @@
     <tr ng-repeat="lineItem in vm.displayedLineItems">
       <td>{{lineItem.occurredDate | openlmisDate}}</td>
       <td>
-        {{lineItem.sourceFreeText ? ('stockCard.srcDstAndFreeText' |
-        message: {name:lineItem.source.name, freeText: lineItem.sourceFreeText}) : lineItem.source.name}}
+        <span class="openlmis-long-text">{{lineItem.sourceFreeText ? ('stockCard.srcDstAndFreeText' |
+        message: {name:lineItem.source.name, freeText: lineItem.sourceFreeText}) : lineItem.source.name}}</span>
       </td>
       <td>
-        {{lineItem.destinationFreeText ? ('stockCard.srcDstAndFreeText' |
-        message: {name:lineItem.destination.name, freeText: lineItem.destinationFreeText}) : lineItem.destination.name}}
+        <span class="openlmis-long-text">{{lineItem.destinationFreeText ? ('stockCard.srcDstAndFreeText' |
+        message: {name:lineItem.destination.name, freeText: lineItem.destinationFreeText}) : lineItem.destination.name}}</span>
       </td>
       <td>
-        {{ vm.getReason(lineItem) }}
+        <span class="openlmis-long-text">{{ vm.getReason(lineItem) }}</span>
       </td>
       <td align="right">{{vm.recalculateQuantity(lineItem.quantity)}}</td>
       <td align="right">{{vm.recalculateQuantity(lineItem.stockOnHand)}}</td>


### PR DESCRIPTION
## What
- Stock adjustment source/destination and reason free-text: growing textareas with the shared `openlmis-long-text` class (the reason comment was a single-line `<input>`), capped to 255 (`STOCK_ADJUSTMENT_FREE_TEXT_MAX_LENGTH`) with the `characters-left` counter and a hard `maxlength` (also truncates paste).
- Stock Card read-only source/destination/reason cells wrap via the class.

## Design decision (please confirm)
Hard native `maxlength` — same rationale as the requisition-ui PR.

## Depends on
openlmis-ui-components PR (same branch).

OLMIS-8191
