### PR TITLE
SELV3-860: Add cancellation cross-link columns to stock detail views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.2.0-SNAPSHOT (WIP)
 ==================
+* [SELV3-860](https://openlmis.atlassian.net/browse/SELV3-860): Added "Reversing" and "Reversed by" cancellation cross-link columns, with clickable links to the related event, on the Stock on Hand bin card and the Transaction History detail views.
 * [OLMIS-8179](https://openlmis.atlassian.net/browse/OLMIS-8179): Remove unit suffix from stock management column headers.
 * [OLMIS-8198](https://openlmis.atlassian.net/browse/OLMIS-8198): Pass the selected quantity unit to stock card report print.
 * [SELV3-842](https://openlmis.atlassian.net/browse/SELV3-842): Added Transaction History header, packs/doses support, reorder stockmanagement menu entries

--- a/src/stock-card/messages_en.json
+++ b/src/stock-card/messages_en.json
@@ -18,5 +18,8 @@
   "stockCard.expiryDate": "Expiry date",
   "stockCard.physicalInventory": "Physical Inventory",
   "stockCard.print": "Print",
-  "stockCard.notCached.error": "This stock card isn't cached. You'll need to go online to view and save it for offline use."
+  "stockCard.notCached.error": "This stock card isn't cached. You'll need to go online to view and save it for offline use.",
+  "stockCard.reversing": "Reversing",
+  "stockCard.reversedBy": "Reversed by",
+  "stockCard.viewEvent": "View"
 }

--- a/src/stock-card/stock-card.html
+++ b/src/stock-card/stock-card.html
@@ -53,6 +53,8 @@
       <th>{{'stockCard.performedBy' | message}}</th>
       <th>{{'stockCard.signature' | message}}</th>
       <th>{{'stockCard.documentNumber' | message}}</th>
+      <th>{{'stockCard.reversing' | message}}</th>
+      <th>{{'stockCard.reversedBy' | message}}</th>
     </tr>
     </thead>
     <tbody>
@@ -76,6 +78,14 @@
       <td>
         <a ng-if="lineItem.eventOrigin"
            ng-click="vm.viewTransaction(lineItem.originEventId)">{{lineItem.documentNumber}}</a>
+      </td>
+      <td>
+        <a ng-if="lineItem.reversedEventId"
+           ng-click="vm.viewTransaction(lineItem.reversedEventId)">{{lineItem.reversedEventDocumentNumber || ('stockCard.viewEvent' | message)}}</a>
+      </td>
+      <td>
+        <a ng-if="lineItem.cancellationEventId"
+           ng-click="vm.viewTransaction(lineItem.cancellationEventId)">{{lineItem.cancellationEventDocumentNumber || ('stockCard.viewEvent' | message)}}</a>
       </td>
     </tr>
     </tbody>

--- a/src/stock-transaction-history/messages_en.json
+++ b/src/stock-transaction-history/messages_en.json
@@ -28,5 +28,8 @@
     "stockTransactionHistory.noLot": "No lot defined",
     "stockTransactionHistory.noLineItems": "No line items found.",
     "stockTransactionHistory.print": "Print",
-    "stockTransactionHistory.date": "Date"
+    "stockTransactionHistory.date": "Date",
+    "stockTransactionHistory.reversing": "Reversing",
+    "stockTransactionHistory.reversedBy": "Reversed by",
+    "stockTransactionHistory.viewEvent": "View"
 }

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.js
@@ -30,12 +30,12 @@
         .controller('TransactionHistoryDetailController', controller);
 
     controller.$inject = [
-        'stockEvent', 'lineItems', 'dateUtils', '$stateParams', '$window', 'QUANTITY_UNIT',
+        'stockEvent', 'lineItems', 'dateUtils', '$stateParams', '$state', '$window', 'QUANTITY_UNIT',
         'localStorageService', 'accessTokenFactory', 'stockmanagementUrlFactory',
         'quantityUnitCalculateService'
     ];
 
-    function controller(stockEvent, lineItems, dateUtils, $stateParams, $window, QUANTITY_UNIT,
+    function controller(stockEvent, lineItems, dateUtils, $stateParams, $state, $window, QUANTITY_UNIT,
                         localStorageService, accessTokenFactory, stockmanagementUrlFactory,
                         quantityUnitCalculateService) {
         const vm = this;
@@ -44,6 +44,7 @@
         vm.showInDoses = showInDoses;
         vm.recalculateQuantity = recalculateQuantity;
         vm.print = print;
+        vm.viewTransaction = viewTransaction;
 
         /**
          * @ngdoc property
@@ -159,6 +160,23 @@
                 '/api/stockEvents/' + $stateParams.stockEventId + '/print?' + params
             );
             $window.open(accessTokenFactory.addAccessToken(url), '_blank');
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf stock-transaction-history.controller:TransactionHistoryDetailController
+         * @name viewTransaction
+         *
+         * @description
+         * Navigates to the transaction history detail of another stock event - used by the
+         * "Reversing" / "Reversed by" links to jump to the linked (origin or cancellation) event.
+         *
+         * @param {String} stockEventId the id of the stock event to open
+         */
+        function viewTransaction(stockEventId) {
+            $state.go('openlmis.stockmanagement.transactionHistory.detail', {
+                stockEventId: stockEventId
+            });
         }
     }
 })();

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.js
@@ -170,12 +170,15 @@
          * @description
          * Navigates to the transaction history detail of another stock event - used by the
          * "Reversing" / "Reversed by" links to jump to the linked (origin or cancellation) event.
+         * The detail page is reset to the first page, otherwise the current detailPage is inherited
+         * and the linked event may open on a page it does not have (showing an empty table).
          *
          * @param {String} stockEventId the id of the stock event to open
          */
         function viewTransaction(stockEventId) {
             $state.go('openlmis.stockmanagement.transactionHistory.detail', {
-                stockEventId: stockEventId
+                stockEventId: stockEventId,
+                detailPage: 0
             });
         }
     }

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
@@ -202,7 +202,8 @@ describe('TransactionHistoryDetailController', function() {
             expect($state.go).toHaveBeenCalledWith(
                 'openlmis.stockmanagement.transactionHistory.detail',
                 {
-                    stockEventId: 'event-2'
+                    stockEventId: 'event-2',
+                    detailPage: 0
                 }
             );
         });

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
@@ -15,7 +15,7 @@
 
 describe('TransactionHistoryDetailController', function() {
 
-    let vm, $controller, stockEvent, lineItems, $window, $stateParams, QUANTITY_UNIT,
+    let vm, $controller, $state, stockEvent, lineItems, $window, $stateParams, QUANTITY_UNIT,
         localStorageService, accessTokenFactory, stockmanagementUrlFactory,
         quantityUnitCalculateService;
 
@@ -24,6 +24,7 @@ describe('TransactionHistoryDetailController', function() {
 
         inject(function($injector) {
             $controller = $injector.get('$controller');
+            $state = $injector.get('$state');
         });
 
         QUANTITY_UNIT = {
@@ -81,6 +82,7 @@ describe('TransactionHistoryDetailController', function() {
             stockEvent: event === undefined ? stockEvent : event,
             lineItems: items,
             $stateParams: $stateParams,
+            $state: $state,
             $window: $window,
             QUANTITY_UNIT: QUANTITY_UNIT,
             localStorageService: localStorageService,
@@ -187,6 +189,22 @@ describe('TransactionHistoryDetailController', function() {
 
             expect(stockmanagementUrlFactory)
                 .toHaveBeenCalledWith('/api/stockEvents/event-1/print?showInDoses=false&lang=fr');
+        });
+    });
+
+    describe('viewTransaction', function() {
+
+        it('should navigate to the transaction history detail for the given event', function() {
+            spyOn($state, 'go');
+
+            vm.viewTransaction('event-2');
+
+            expect($state.go).toHaveBeenCalledWith(
+                'openlmis.stockmanagement.transactionHistory.detail',
+                {
+                    stockEventId: 'event-2'
+                }
+            );
         });
     });
 });

--- a/src/stock-transaction-history/stock-transaction-history-detail.html
+++ b/src/stock-transaction-history/stock-transaction-history-detail.html
@@ -48,6 +48,8 @@
                 <th>{{'stockTransactionHistory.quantity' | message}}</th>
                 <th>{{'stockTransactionHistory.reason' | message}}</th>
                 <th>{{'stockTransactionHistory.stockOnHand' | message}}</th>
+                <th>{{'stockTransactionHistory.reversing' | message}}</th>
+                <th>{{'stockTransactionHistory.reversedBy' | message}}</th>
             </tr>
         </thead>
         <tbody>
@@ -61,6 +63,14 @@
                 <td>{{vm.recalculateQuantity(lineItem.quantity, lineItem)}}</td>
                 <td>{{lineItem.reason ? lineItem.reason.name : ''}}</td>
                 <td>{{vm.recalculateQuantity(lineItem.stockOnHand, lineItem)}}</td>
+                <td>
+                    <a ng-if="lineItem.reversedEventId"
+                       ng-click="vm.viewTransaction(lineItem.reversedEventId)">{{lineItem.reversedEventDocumentNumber || ('stockTransactionHistory.viewEvent' | message)}}</a>
+                </td>
+                <td>
+                    <a ng-if="lineItem.cancellationEventId"
+                       ng-click="vm.viewTransaction(lineItem.cancellationEventId)">{{lineItem.cancellationEventDocumentNumber || ('stockTransactionHistory.viewEvent' | message)}}</a>
+                </td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
Adds the two cancellation cross-link columns to the Bin Card and Transaction History detail
views (SELV3-860) — a clickable link between an issue/receive movement and the event that
cancelled it, in both directions:
- **Reversing** — on a cancellation row, links to the original event it reverses.
- **Reversed by** — on an original row, links to the cancellation event that reversed it.

Populated by the read-side fields from the SELV3-861 backend PR (`reversedEvent*` /
`cancellationEvent*`); this PR is UI-only and inert without it.

## What changed
- **Bin Card** (`stock-card/stock-card.html`) — two columns after *Document Number*, linked
  via the existing `vm.viewTransaction(id)`.
- **Transaction History detail** (`stock-transaction-history/…-detail.html` + `.controller.js`)
  — the same two columns; the controller gains `$state` + a `viewTransaction` method.
- **Link label** — shows the linked event's document number, falling back to **"View"** when
  it has none (cancellation events carry no document number).
- **i18n** — `reversing`, `reversedBy`, `viewEvent` in both modules' `messages_en.json`.
- Removes the temporary CANCELLATION badge, superseded by the Reversing column
  (`isCancellation` + its spec, the flag style, and the `stockCard.cancellation` key).

## Testing
- `grunt eslint` clean; `grunt test` green (2872 specs), incl. a new `viewTransaction` spec.
- E2E on ref-distro: cancelled a receive line → the Bin Card and both events' detail views show
  the links; navigation works both directions (original ⇄ cancellation).

## Notes for reviewers
- Depends on **SELV3-861** (backend) for the DTO fields — merge/deploy alongside it.
- "View" is a fallback label; the team may later prefer the linked event's date, or assigning
  document numbers to cancellation events (open question).