### PR TITLE
[SELV3-856] Reverse transaction QA changes

### DIFF
--- a/src/stock-transaction-history/messages_en.json
+++ b/src/stock-transaction-history/messages_en.json
@@ -7,6 +7,7 @@
     "stockTransactionHistory.typeAll": "All",
     "stockTransactionHistory.typeIssue": "Issue",
     "stockTransactionHistory.typeReceive": "Receive",
+    "stockTransactionHistory.typeAdjustment": "Adjustment",
     "stockTransactionHistory.startDate": "Start date",
     "stockTransactionHistory.endDate": "End date",
     "stockTransactionHistory.documentNumber": "Document Number",

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.js
@@ -40,6 +40,8 @@
                         quantityUnitCalculateService, canReverse, transactionHistoryReverseFactory) {
         const vm = this;
 
+        const ADJUSTMENT_TYPE = 'ADJUSTMENT';
+
         vm.$onInit = onInit;
         vm.showInDoses = showInDoses;
         vm.recalculateQuantity = recalculateQuantity;
@@ -83,7 +85,8 @@
          */
         vm.typeLabels = {
             ISSUE: 'stockTransactionHistory.typeIssue',
-            RECEIVE: 'stockTransactionHistory.typeReceive'
+            RECEIVE: 'stockTransactionHistory.typeReceive',
+            ADJUSTMENT: 'stockTransactionHistory.typeAdjustment'
         };
 
         /**
@@ -105,7 +108,11 @@
                     lineItem.lot.expirationDate = dateUtils.toDate(lineItem.lot.expirationDate);
                 }
             });
-            vm.canReverse = canReverse;
+            // An adjustment is itself a reversal, and the server rejects cancelling one, so the
+            // reverse view would have nothing selectable - do not offer it.
+            vm.canReverse = canReverse
+                && !!stockEvent
+                && stockEvent.type !== ADJUSTMENT_TYPE;
         }
 
         /**

--- a/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
+++ b/src/stock-transaction-history/stock-transaction-history-detail.controller.spec.js
@@ -149,6 +149,15 @@ describe('TransactionHistoryDetailController', function() {
             expect(vm.canReverse).toBe(false);
         });
 
+        it('should not offer reversing an adjustment, which is itself a reversal', function() {
+            const adjustment = angular.copy(stockEvent);
+            adjustment.type = 'ADJUSTMENT';
+
+            initController(lineItems, adjustment, true);
+
+            expect(vm.canReverse).toBe(false);
+        });
+
         it('should drop cached reverse rows and open the reverse view', function() {
             vm.goToReverse();
 

--- a/src/stock-transaction-history/stock-transaction-history-list.controller.js
+++ b/src/stock-transaction-history/stock-transaction-history-list.controller.js
@@ -61,6 +61,10 @@
             {
                 value: 'receive',
                 name: messageService.get('stockTransactionHistory.typeReceive')
+            },
+            {
+                value: 'adjustment',
+                name: messageService.get('stockTransactionHistory.typeAdjustment')
             }
         ];
 
@@ -76,7 +80,8 @@
          */
         vm.typeLabels = {
             ISSUE: 'stockTransactionHistory.typeIssue',
-            RECEIVE: 'stockTransactionHistory.typeReceive'
+            RECEIVE: 'stockTransactionHistory.typeReceive',
+            ADJUSTMENT: 'stockTransactionHistory.typeAdjustment'
         };
 
         /**

--- a/src/stock-transaction-history/stock-transaction-history-list.controller.spec.js
+++ b/src/stock-transaction-history/stock-transaction-history-list.controller.spec.js
@@ -76,10 +76,11 @@ describe('TransactionHistoryListController', function() {
             return option.value;
         });
 
-        expect(values).toEqual(['', 'issue', 'receive']);
+        expect(values).toEqual(['', 'issue', 'receive', 'adjustment']);
         expect(vm.transactionTypes[0].name).toEqual('stockTransactionHistory.typeAll');
         expect(vm.transactionTypes[1].name).toEqual('stockTransactionHistory.typeIssue');
         expect(vm.transactionTypes[2].name).toEqual('stockTransactionHistory.typeReceive');
+        expect(vm.transactionTypes[3].name).toEqual('stockTransactionHistory.typeAdjustment');
     });
 
     it('should navigate to the detail state on viewTransaction', function() {

--- a/src/stock-transaction-history/stock-transaction-history-reverse.controller.js
+++ b/src/stock-transaction-history/stock-transaction-history-reverse.controller.js
@@ -81,7 +81,8 @@
          */
         vm.typeLabels = {
             ISSUE: 'stockTransactionHistory.typeIssue',
-            RECEIVE: 'stockTransactionHistory.typeReceive'
+            RECEIVE: 'stockTransactionHistory.typeReceive',
+            ADJUSTMENT: 'stockTransactionHistory.typeAdjustment'
         };
 
         /**

--- a/src/stock-transaction-history/stock-transaction-history-reverse.html
+++ b/src/stock-transaction-history/stock-transaction-history-reverse.html
@@ -79,7 +79,7 @@
                         aria-label="{{'stockTransactionHistoryReverse.reversed' | message}}"></i>
                 </td>
                 <td openlmis-invalid="{{lineItem.$errors.reasonInvalid ? 'openlmisForm.required' : '' | message}}">
-                    <select ng-if="lineItem.$selected"
+                    <select ng-show="lineItem.$selected"
                         id="reverse-reason-{{$index}}"
                         aria-label="{{'stockTransactionHistoryReverse.cancelReason' | message}}: {{lineItem.orderable.fullProductName}}"
                         ng-model="lineItem.$reason"
@@ -88,7 +88,7 @@
                     </select>
                 </td>
                 <td>
-                    <textarea ng-if="lineItem.$selected && lineItem.$reason.isFreeTextAllowed"
+                    <textarea ng-show="lineItem.$selected && lineItem.$reason.isFreeTextAllowed"
                         id="reverse-reason-free-text-{{$index}}"
                         aria-label="{{'stockTransactionHistoryReverse.cancelReasonFreeText' | message}}: {{lineItem.orderable.fullProductName}}"
                         ng-attr-maxlength="{{vm.freeTextMaxLength}}"


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/SELV3-856
Description:
## SELV3-856: Reverse view QA fixes

1. **Duplicated inputs** - checking/unchecking a row repeatedly added another reason
   dropdown and comment field. `ng-if` on the `<select>`/`<textarea>` orphaned the
   `[input-control]` wrapper that `input-control-wrap` injects around them; switched to
   `ng-show`, which the directive supports and which destroys nothing.

2. **Empty Type for reversals** - added the `ADJUSTMENT` label to the list, detail and
   reverse controllers, a `stockTransactionHistory.typeAdjustment` message, and an
   "Adjustment" option to the list type filter. Needs the matching backend change.

3. **Reverse view reachable for a reversal** - the Reverse button is now hidden for
   adjustments, which cannot be cancelled.