### PR TITLE
SELV3-863: List manual adjustments in transaction history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.2.0-SNAPSHOT (WIP)
 ==================
+* [SELV3-863](https://openlmis.atlassian.net/browse/SELV3-863): List manual adjustments in the Transaction History view by recording their ADJUSTMENT event origin, so they are filtered and shown like issues and receives.
 * [SELV3-859](https://openlmis.atlassian.net/browse/SELV3-859): Added the Reverse Transaction view for cancelling selected issue/receive line items.
 * [SELV3-860](https://openlmis.atlassian.net/browse/SELV3-860): Added "Reversing" and "Reversed by" cancellation cross-link columns, with clickable links to the related event, on the Stock on Hand bin card and the Transaction History detail views.
 * [OLMIS-8179](https://openlmis.atlassian.net/browse/OLMIS-8179): Remove unit suffix from stock management column headers.

--- a/src/stock-adjustment-creation/adjustment-creation.service.js
+++ b/src/stock-adjustment-creation/adjustment-creation.service.js
@@ -116,6 +116,9 @@
             if (adjustmentType.state === 'receive') {
                 return 'RECEIVE';
             }
+            if (adjustmentType.state === 'adjustment') {
+                return 'ADJUSTMENT';
+            }
             return null;
         }
 

--- a/src/stock-adjustment-creation/adjustment-creation.service.spec.js
+++ b/src/stock-adjustment-creation/adjustment-creation.service.spec.js
@@ -242,7 +242,7 @@ describe('stockAdjustmentCreationService', function() {
             expect(submittedEvent.eventOrigin).toBe('ISSUE');
         });
 
-        it('should not set eventOrigin for adjustment state', function() {
+        it('should set eventOrigin ADJUSTMENT for adjustment state', function() {
             service.submitAdjustments(programId, facilityId, lineItems, {
                 state: 'adjustment'
             });
@@ -250,7 +250,7 @@ describe('stockAdjustmentCreationService', function() {
 
             var submittedEvent = stockEventRepositoryMock.create.mostRecentCall.args[0];
 
-            expect(submittedEvent.eventOrigin).toBeUndefined();
+            expect(submittedEvent.eventOrigin).toBe('ADJUSTMENT');
         });
 
         it('should not set eventOrigin for kit unpack state', function() {


### PR DESCRIPTION
## Summary
Manual adjustments were not showing up in transaction history. The view already filters and labels events by `eventOrigin`, and the backend already lists `ADJUSTMENT` events, but a manual adjustment was submitted with no `eventOrigin`, so it was filtered out.

## Change
`resolveEventOrigin` now returns `ADJUSTMENT` for the adjustment state, so a manual adjustment carries `eventOrigin=ADJUSTMENT` and lists alongside issues and receives. The unit spec was updated to match.

## Testing
`eslint` passes. Verified end to end on ref-distro: a manual adjustment now appears under the Adjustment filter, with its type shown in the detail header.
