### PR TITLE
SELV3-866: Collect signature when submitting a manual adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 2.2.0-SNAPSHOT (WIP)
 ==================
+* [SELV3-866](https://openlmis.atlassian.net/browse/SELV3-866): Show the signature modal when submitting a manual adjustment, like issues and receives, so the signature is captured with the stock event. The signature stays optional.
 * [SELV3-863](https://openlmis.atlassian.net/browse/SELV3-863): List manual adjustments in the Transaction History view by recording their ADJUSTMENT event origin, so they are filtered and shown like issues and receives.
 * [SELV3-859](https://openlmis.atlassian.net/browse/SELV3-859): Added the Reverse Transaction view for cancelling selected issue/receive line items.
 * [SELV3-860](https://openlmis.atlassian.net/browse/SELV3-860): Added "Reversing" and "Reversed by" cancellation cross-link columns, with clickable links to the related event, on the Stock on Hand bin card and the Transaction History detail views.

--- a/src/stock-adjustment-creation/adjustment-creation.controller.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.js
@@ -407,7 +407,8 @@
 
         function shouldCollectSignature() {
             return adjustmentType.state === ADJUSTMENT_TYPE.ISSUE.state ||
-                adjustmentType.state === ADJUSTMENT_TYPE.RECEIVE.state;
+                adjustmentType.state === ADJUSTMENT_TYPE.RECEIVE.state ||
+                adjustmentType.state === ADJUSTMENT_TYPE.ADJUSTMENT.state;
         }
 
         /**

--- a/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
+++ b/src/stock-adjustment-creation/adjustment-creation.controller.spec.js
@@ -558,14 +558,14 @@ describe('StockAdjustmentCreationController', function() {
             expect(this.signatureModalService.show).toHaveBeenCalled();
         });
 
-        it('should not show signature modal for ADJUSTMENT', function() {
+        it('should show signature modal for ADJUSTMENT', function() {
             vm = initController(orderableGroups, ADJUSTMENT_TYPE.ADJUSTMENT);
             spyOn(stockAdjustmentCreationService, 'submitAdjustments').andReturn(q.resolve());
 
             vm.submit();
             rootScope.$apply();
 
-            expect(this.signatureModalService.show).not.toHaveBeenCalled();
+            expect(this.signatureModalService.show).toHaveBeenCalled();
         });
 
         it('should not show signature modal for KIT_UNPACK', function() {
@@ -593,15 +593,18 @@ describe('StockAdjustmentCreationController', function() {
             );
         });
 
-        it('should pass null signature to submitAdjustments for ADJUSTMENT', function() {
+        it('should pass collected signature to submitAdjustments for ADJUSTMENT', function() {
             vm = initController(orderableGroups, ADJUSTMENT_TYPE.ADJUSTMENT);
+            this.signatureModalService.show.andReturn(q.resolve({
+                signature: 'Test Signature'
+            }));
             spyOn(stockAdjustmentCreationService, 'submitAdjustments').andReturn(q.resolve());
 
             vm.submit();
             rootScope.$apply();
 
             expect(stockAdjustmentCreationService.submitAdjustments).toHaveBeenCalledWith(
-                program.id, facility.id, jasmine.any(Array), ADJUSTMENT_TYPE.ADJUSTMENT, null
+                program.id, facility.id, jasmine.any(Array), ADJUSTMENT_TYPE.ADJUSTMENT, 'Test Signature'
             );
         });
 
@@ -627,15 +630,15 @@ describe('StockAdjustmentCreationController', function() {
             expect(this.signatureModalService.show).toHaveBeenCalled();
         });
 
-        it('should show confirmation modal for ADJUSTMENT', function() {
+        it('should not show confirmation modal for ADJUSTMENT', function() {
             vm = initController(orderableGroups, ADJUSTMENT_TYPE.ADJUSTMENT);
             spyOn(stockAdjustmentCreationService, 'submitAdjustments').andReturn(q.resolve());
 
             vm.submit();
             rootScope.$apply();
 
-            expect(confirmService.confirm).toHaveBeenCalled();
-            expect(this.signatureModalService.show).not.toHaveBeenCalled();
+            expect(confirmService.confirm).not.toHaveBeenCalled();
+            expect(this.signatureModalService.show).toHaveBeenCalled();
         });
 
         it('should show confirmation modal for KIT_UNPACK', function() {


### PR DESCRIPTION
[SELV3-866](https://openlmis.atlassian.net/browse/SELV3-866)

After SELV3-863 manual adjustments already get an event_origin and a document_number (the shared stock event processor generates the number for any event that carries an origin) and they show up in Transaction History. The only piece still missing was the signature: the signature modal appeared only for issues and receives, so adjustments were always submitted without one.

This makes the signature modal show on adjustment submission too, just like issue and receive. The signature stays optional, so a user can still submit without signing. The rest of the pipeline was already there: `submitAdjustments` forwards the signature and the backend persists it, so no service or backend change was needed.

Changes:
* `shouldCollectSignature()` now also matches the adjustment state.
* Updated the three controller specs that locked in the old no-signature behavior. Kit unpack still uses the plain confirmation dialog.
* Changelog entry.

`shouldOfferPrint()` is left as is (printing the report after submit is out of scope for this ticket).

Verified on UAT: a manual adjustment (document 2026-08-HC01-0008) lists in Transaction History with its type and document number; before this change its signature column was empty while issue/receive events had one.


[SELV3-866]: https://openlmis.atlassian.net/browse/SELV3-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ